### PR TITLE
Only cache page if caching is enabled in Rails app

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -184,7 +184,9 @@ module Alchemy
     # @returns Boolean
     #
     def cache_page?
-      return false unless @page && Alchemy::Config.get(:cache_pages)
+      return false if @page.nil? ||
+        !Rails.application.config.action_controller.perform_caching ||
+        !Alchemy::Config.get(:cache_pages)
       page_layout = PageLayout.get(@page.page_layout)
       page_layout['cache'] != false && page_layout['searchresults'] != true
     end


### PR DESCRIPTION
HTTP caching was enabled in the development environment, because Alchemy didn't check for the Rails application configuration.